### PR TITLE
Reconfigured K8 Docker Compose setup

### DIFF
--- a/service/src/test/resources/docker-compose-k8-integration.yaml
+++ b/service/src/test/resources/docker-compose-k8-integration.yaml
@@ -20,7 +20,7 @@ services:
     network_mode: host
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    image: jsquadab/k3dcontainer:latest
+    image: mrasimov/k3dcontainer:latest
     environment:
       CLUSTER_NAME: "jsquad"
       CLUSTER_API_PORT: "6443"


### PR DESCRIPTION
Updated the Docker Compose k3dcontainer reference used by Kubernetes
integration tests to mrasimov dockerhub/k3dcontainer repository.